### PR TITLE
Added $data filters to create, update, meta, and abstract API classes

### DIFF
--- a/inc/api/class-wprus-api-abstract.php
+++ b/inc/api/class-wprus-api-abstract.php
@@ -885,6 +885,8 @@ class Wprus_Api_Abstract {
 
 		do_action( 'wprus_before_firing_action', $endpoint, $url, $data );
 
+		$data = apply_filters( 'wprus_api_abstract_data', $data, $url );
+
 		$body     = array(
 			'wprusdata' => $this->encrypt_data( $data ),
 			'token'     => $this->get_token( $url, $data['username'], 'post' ),

--- a/inc/api/class-wprus-api-create.php
+++ b/inc/api/class-wprus-api-create.php
@@ -121,6 +121,8 @@ class Wprus_Api_Create extends Wprus_Api_Abstract {
 				'locale'               => $user->locale,
 			);
 
+			$data = apply_filters( 'wprus_api_create_data', $data, $user_id );
+
 			Wprus_Logger::log(
 				sprintf(
 					// translators: %s is the username

--- a/inc/api/class-wprus-api-meta.php
+++ b/inc/api/class-wprus-api-meta.php
@@ -316,6 +316,10 @@ class Wprus_Api_Meta extends Wprus_Api_Abstract {
 					$data             = $meta_changes;
 					$data['username'] = $username;
 
+					$user = get_user_by( 'login', $username );
+
+					$data = apply_filters( 'wprus_api_meta_data', $data, $user->ID );
+
 					$this->fire_action( $site_url, $data );
 				}
 			}

--- a/inc/api/class-wprus-api-update.php
+++ b/inc/api/class-wprus-api-update.php
@@ -163,6 +163,8 @@ class Wprus_Api_Update extends Wprus_Api_Abstract {
 				'locale'               => $user->locale,
 			);
 
+			$data = apply_filters( 'wprus_api_update_data', $data, $user_id );
+
 			Wprus_Logger::log(
 				sprintf(
 					// translators: %s is the username


### PR DESCRIPTION
Suggesting a few additional filters in the outgoing `$data` array for the create, update and meta `fire_remote()` functions, as well a generic one in `fire_action()`