### PR TITLE
Functionality to whitelist IP ranges

### DIFF
--- a/inc/api/class-wprus-api-abstract.php
+++ b/inc/api/class-wprus-api-abstract.php
@@ -20,7 +20,7 @@ class Wprus_Api_Abstract {
 	 */
 	protected static $browser_support_settings;
 	/**
-	 * The whitelist of IP addresses.
+	 * The whitelist of IP ranges.
 	 *
 	 * @var array
 	 */
@@ -214,7 +214,13 @@ class Wprus_Api_Abstract {
 			$ip_whitelist = self::$settings_class::get_option( 'ip_whitelist' );
 
 			if ( ! empty( $ip_whitelist ) ) {
-				self::$ip_whitelist = array_filter( array_map( 'trim', explode( "\n", $ip_whitelist ) ) );
+				$ip_whitelist = array_filter( array_map( 'trim', explode( "\n", $ip_whitelist ) ) );
+				self::$ip_whitelist = array_map(
+					function ( $ip ) {
+						return preg_match( '/\//', $ip ) ? $ip : $ip . '/32';
+					},
+					$ip_whitelist
+				);
 			} else {
 				self::$ip_whitelist = false;
 			}
@@ -349,7 +355,13 @@ class Wprus_Api_Abstract {
 			} elseif ( 'post' === $this->method ) {
 
 				if ( self::$ip_whitelist ) {
-					$is_authorized_remote = in_array( $_SERVER['REMOTE_ADDR'], self::$ip_whitelist, true );
+					foreach ( self::$ip_whitelist as $range ) {
+						if ( self::cidr_match( $_SERVER['REMOTE_ADDR'], $range ) ) {
+							$is_authorized_remote = true;
+							break;
+						}
+					}
+					
 				} else {
 					$is_authorized_remote = true;
 				}
@@ -1300,4 +1312,18 @@ class Wprus_Api_Abstract {
 		return $output;
 	}
 
+	/**
+	 * check if ip is in range
+	 *
+	 * @param string $ip The ip address to check against the range
+	 * @param string $range
+	 * @return bool True if the ip is in range, false otherwise
+	 */
+	protected function cidr_match( $ip, $range ) {
+		$ip    = ip2long( $ip );
+		$range = ip2long( $range );
+		$range = $range & 0xFFFFFF00;
+
+		return ( $ip & $range ) == $range;
+	}
 }

--- a/inc/api/class-wprus-api-abstract.php
+++ b/inc/api/class-wprus-api-abstract.php
@@ -356,12 +356,11 @@ class Wprus_Api_Abstract {
 
 				if ( self::$ip_whitelist ) {
 					foreach ( self::$ip_whitelist as $range ) {
-						if ( self::cidr_match( $_SERVER['REMOTE_ADDR'], $range ) ) {
+						if ( $this->cidr_match( $_SERVER['REMOTE_ADDR'], $range ) ) {
 							$is_authorized_remote = true;
 							break;
 						}
 					}
-					
 				} else {
 					$is_authorized_remote = true;
 				}
@@ -1316,7 +1315,7 @@ class Wprus_Api_Abstract {
 	 * check if ip is in range
 	 *
 	 * @param string $ip The ip address to check against the range
-	 * @param string $range
+	 * @param string $range The CIDR
 	 * @return bool True if the ip is in range, false otherwise
 	 */
 	protected function cidr_match( $ip, $range ) {

--- a/inc/api/class-wprus-api-abstract.php
+++ b/inc/api/class-wprus-api-abstract.php
@@ -357,19 +357,7 @@ class Wprus_Api_Abstract {
 				if ( self::$ip_whitelist ) {
 					foreach ( self::$ip_whitelist as $range ) {
 						if ( self::cidr_match( $_SERVER['REMOTE_ADDR'], $range ) ) {
-			function cidr_match($ip, $range){
-    list ($subnet, $bits) = explode('/', $range);
-    $ip = ip2long($ip);
-    $subnet = ip2long($subnet);
-    
-    if ( !$ip || !$subnet || !$bits) {
-      return false;
-    }
-    
-    $mask = -1 << (32 - $bits);
-    $subnet &= $mask; // in case the supplied subnet was not correctly aligned
-    return ($ip & $mask) == $subnet;
-}				$is_authorized_remote = true;
+							$is_authorized_remote = true;
 							break;
 						}
 					}

--- a/inc/api/class-wprus-api-abstract.php
+++ b/inc/api/class-wprus-api-abstract.php
@@ -357,7 +357,19 @@ class Wprus_Api_Abstract {
 				if ( self::$ip_whitelist ) {
 					foreach ( self::$ip_whitelist as $range ) {
 						if ( self::cidr_match( $_SERVER['REMOTE_ADDR'], $range ) ) {
-							$is_authorized_remote = true;
+			function cidr_match($ip, $range){
+    list ($subnet, $bits) = explode('/', $range);
+    $ip = ip2long($ip);
+    $subnet = ip2long($subnet);
+    
+    if ( !$ip || !$subnet || !$bits) {
+      return false;
+    }
+    
+    $mask = -1 << (32 - $bits);
+    $subnet &= $mask; // in case the supplied subnet was not correctly aligned
+    return ($ip & $mask) == $subnet;
+}				$is_authorized_remote = true;
 							break;
 						}
 					}
@@ -1320,10 +1332,16 @@ class Wprus_Api_Abstract {
 	 * @return bool True if the ip is in range, false otherwise
 	 */
 	protected function cidr_match( $ip, $range ) {
-		$ip    = ip2long( $ip );
-		$range = ip2long( $range );
-		$range = $range & 0xFFFFFF00;
-
-		return ( $ip & $range ) == $range;
+		list ($subnet, $bits) = explode('/', $range);
+		$ip = ip2long($ip);
+		$subnet = ip2long($subnet);
+		
+		if ( !$ip || !$subnet || !$bits ) {
+		  return false;
+		}
+		
+		$mask = -1 << (32 - $bits);
+		$subnet &= $mask; // in case the supplied subnet was not correctly aligned
+		return ($ip & $mask) == $subnet;
 	}
 }

--- a/inc/templates/admin/ip-whitelist-metabox.php
+++ b/inc/templates/admin/ip-whitelist-metabox.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div class="wprus-container" data-postbox_class="wprus-security wprus-togglable">
 	<textarea id="wprus_ip_whitelist" name="wprus[ip_whitelist]"><?php echo esc_html( $ips ); ?></textarea>
 	<p class="howto">
-		<?php esc_html_e( 'List of IP addresses of remote sites to authorise (one per line).', 'wprus' ); ?> <br/>
+		<?php esc_html_e( 'List of IP addresses and/or CIDRs of remote sites to authorise (one IP address or CIDR per line).', 'wprus' ); ?> <br/>
 		<?php esc_html_e( 'To find the IP addresses, use the "Test" button on remote sites while Logs are enabled and check the local log results.', 'wprus' ); ?><br/>
 		<?php esc_html_e( 'Leave blank to accept any IP address (not recommended).', 'wprus' ); ?>
 	</p>


### PR DESCRIPTION
## What?
The current version only supports lists of IP addresses for Wordpress sites to whitelist. This PR expands the functionality to cover IP ranges.

## Why?
For when IP address of Wordpress sites are dynamic within subnets. I ran into this problem as my Wordpress sites were behind Cloudflare proxies and wanted to whitelist Cloudflare IP ranges.
 
## How?
Each item in `$ip_whitelist` will be converted to a valid CIDR, appending `/32` to ip addresses. A new method called `cidr_match` was implemented to check the remote server IP address to the whitelisted CIDRs. 
