### PR TITLE
Added wprus_async_url filter hook

### DIFF
--- a/inc/api/class-wprus-api-abstract.php
+++ b/inc/api/class-wprus-api-abstract.php
@@ -1220,7 +1220,7 @@ abstract class Wprus_Api_Abstract {
 			'wprusdata' => rawurlencode( $this->encrypt_data( $data ) ),
 			'token'     => rawurlencode( $this->get_token( $url, $data['username'], 'get' ) ),
 		);
-		$async_url = add_query_arg( $args, $async_url );
+		$async_url = apply_filters( 'wprus_async_url', add_query_arg( $args, $async_url ), $this->endpoint ) ;
 		$output    = $this->get_async_action_output( $async_url, true );
 
 		update_user_meta( $user_id, 'wprus_' . $this->endpoint . '_pending_async_actions', $actions );
@@ -1262,7 +1262,7 @@ abstract class Wprus_Api_Abstract {
 				'wprusdata' => rawurlencode( $this->encrypt_data( $data ) ),
 				'token'     => rawurlencode( $this->get_token( $url, $data['username'], 'get' ) ),
 			);
-			$async_url = add_query_arg( $args, $async_url );
+			$async_url = apply_filters( 'wprus_async_url', add_query_arg( $args, $async_url ), $this->endpoint ) ;
 			$output   .= $this->get_async_action_output( $async_url );
 
 			Wprus_Logger::log(


### PR DESCRIPTION
We love your plugin, but had an issue with our Rocket.net hosting platform.  The WPRUS async url 'wprus/login' response cookies were being blocked by their CDN.  Our work around was to use a admin-ajax.php url which the hosting service has built-in rules for their CDN cookie policy.   After we generate a custom admin-ajax.php in our custom plugin, then we use the wprus code to authenticate the user and set the wp auth response cookies.  We'd love to have our new filter added to the main branch.